### PR TITLE
Small changes to support reading CommonCrawl files from S3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbt.Keys._
 lazy val commonSettings = Seq(
   name := "archivespark",
   organization := "com.github.helgeho",
-  version := "3.0.1",
+  version := "3.0.3-MMISIEWICZ-SNAPSHOT",
   scalaVersion := "2.11.12",
   fork := true,
   exportJars := true
@@ -16,9 +16,10 @@ lazy val archivespark = (project in file("."))
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
-      "org.apache.hadoop" % "hadoop-client" % "2.5.0" % "provided",
-      "org.apache.spark" %% "spark-core" % "2.1.3" % "provided",
-      "org.apache.spark" %% "spark-sql" % "2.1.3" % "provided",
+      "org.apache.hadoop" % "hadoop-client" % "2.7.2" % "provided",
+      "org.apache.hadoop" % "hadoop-aws" % "2.7.2" % "provided",
+      "org.apache.spark" %% "spark-core" % "2.4.4" % "provided",
+      "org.apache.spark" %% "spark-sql" % "2.4.4" % "provided",
       "joda-time" % "joda-time" % "2.10",
       "org.apache.httpcomponents" % "httpclient" % "4.5.6",
       "org.netpreserve.commons" % "webarchive-commons" % "1.1.8" excludeAll(

--- a/src/main/scala/org/archive/archivespark/sparkling/http/HttpMessage.scala
+++ b/src/main/scala/org/archive/archivespark/sparkling/http/HttpMessage.scala
@@ -41,7 +41,11 @@ class HttpMessage (val statusLine: String, val headers: Map[String, String], val
   lazy val lowerCaseHeaders: Map[String, String] = headers.map{case (k,v) => (k.toLowerCase, v)}
 
   def contentEncoding: Option[String] = lowerCaseHeaders.get("content-encoding").map(_.toLowerCase)
-  def mime: Option[String] = lowerCaseHeaders.get("content-type").map(_.split(';').head.trim.toLowerCase)
+  def mime: Option[String] = Try {
+    lowerCaseHeaders.get("content-type")
+      .map(_.split(';').head.trim.toLowerCase)
+  }.getOrElse(None)
+
   def charset: Option[String] = {
     lowerCaseHeaders.get("content-type").flatMap(_.split(';').drop(1).headOption).map(_.trim)
       .filter(_.startsWith("charset="))

--- a/src/main/scala/org/archive/archivespark/sparkling/io/ByteArray.scala
+++ b/src/main/scala/org/archive/archivespark/sparkling/io/ByteArray.scala
@@ -29,7 +29,7 @@ import java.util.Collections
 
 import scala.collection.JavaConverters._
 
-class ByteArray {
+class ByteArray extends Serializable {
   private val arrays = collection.mutable.Buffer.empty[Array[Byte]]
 
   def append(array: Array[Byte]): Unit = if (array.nonEmpty) arrays += array

--- a/src/main/scala/org/archive/archivespark/sparkling/io/HdfsFileWriter.scala
+++ b/src/main/scala/org/archive/archivespark/sparkling/io/HdfsFileWriter.scala
@@ -45,7 +45,8 @@ class HdfsFileWriter private(filename: String, append: Boolean, replication: Sho
     Log.info("Copying from temporary file " + file.getCanonicalPath + " to " + filename + "...")
     if (append) {
       val in = new FileInputStream(file)
-      val appendOut = HdfsIO.fs.append(new Path(filename))
+      val p = new Path(filename)
+      val appendOut = HdfsIO.fs(p).append(p)
       IOUtil.copy(in, appendOut)
       appendOut.close()
       in.close()

--- a/src/main/scala/org/archive/archivespark/util/FilePathMap.scala
+++ b/src/main/scala/org/archive/archivespark/util/FilePathMap.scala
@@ -33,13 +33,14 @@ case class FilePathMap(path: String, patterns: Seq[String] = Seq.empty) {
   val pathMap: Map[String, String] = {
     var map = collection.mutable.Map[String, String]()
 
-    val fs = FileSystem.get(SparkHadoopUtil.get.conf)
-    val files = fs.listFiles(new Path(path), true)
+    val p = new Path(path)
+    val fs = p.getFileSystem(SparkHadoopUtil.get.conf)
+    val files = fs.listFiles(p, true)
     while (files.hasNext) {
       val path = files.next.getPath
       val filename = path.getName
       if (patterns.isEmpty || patterns.exists(filename.matches)) {
-        if (map.contains(filename)) throw new RuntimeException("duplicate filename: " + filename)
+        if (map.contains(filename)) throw new RuntimeException("duplicate filename: " + filename + " in path: " + path)
         map += filename -> path.getParent.toString.intern
       }
     }


### PR DESCRIPTION
Hello! I've been using `ArchiveSpark` with the CommonCrawl files stored on S3. I found a few items that needed small fixes and I thought I'd send in a PR. I wouldn't say this is 100% ready to
merge - not sure if there any any automated tests to run - but I have been using the code with 
these modifications for a few weeks without issues.

Commit message follows:
This change makes a few modifications to the HDFS utils. Importantly,
the `FileSystem` objects from the hadoop libraries are retrieved from
the URI of the files. This will allow accessing CommonCrawl WARC files
on filesystems other than the currently configured one in the HadoopConf.

Additionally there is a small fix for some sometimes corrupted WARC records
encountered in the output from CommonCrawl.